### PR TITLE
Update CODEOWNERS to be the ospo team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ajhenry
+* @github-community-projects/ospo


### PR DESCRIPTION
This makes the github ospo team to be the proper owners of the ICF repo