### PR TITLE
Add support for EMU workflows

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+import './src/env.mjs'
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@octokit/types": "12.4.0",
         "@primer/octicons-react": "19.8.0",
         "@primer/react": "35.32.2",
+        "@t3-oss/env-nextjs": "0.9.2",
         "@tanstack/react-query": "4.36.1",
         "@trpc/client": "10.44.1",
         "@trpc/next": "10.44.1",
@@ -2617,6 +2618,37 @@
       "integrity": "sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@t3-oss/env-core": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-core/-/env-core-0.9.2.tgz",
+      "integrity": "sha512-KgWXljUTHgO3o7GMZQPAD5+P+HqpauMNNHowlm7V2b9IeMitSUpNKwG6xQrup/xARWHTdxRVIl0mSI4wCevQhQ==",
+      "peerDependencies": {
+        "typescript": ">=5.0.0",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@t3-oss/env-nextjs": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-nextjs/-/env-nextjs-0.9.2.tgz",
+      "integrity": "sha512-dklHrgKLESStNVB67Jdbu6osxDYA+xNKaPBRerlnkEvzbCccSKMvZENx6EZebJuR4snqB3/yRykNMn/bdIAyiQ==",
+      "dependencies": {
+        "@t3-oss/env-core": "0.9.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -11749,7 +11781,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@octokit/types": "12.4.0",
     "@primer/octicons-react": "19.8.0",
     "@primer/react": "35.32.2",
+    "@t3-oss/env-nextjs": "0.9.2",
     "@tanstack/react-query": "4.36.1",
     "@trpc/client": "10.44.1",
     "@trpc/next": "10.44.1",

--- a/src/bot/config.ts
+++ b/src/bot/config.ts
@@ -20,7 +20,33 @@ type InternalContributionForksConfig = z.infer<
  * @param orgId Organization ID
  * @returns Configuration file
  */
-export const getConfig = async (orgId: string) => {
+export const getConfig = async (orgId?: string) => {
+  // First check if there's a config file in the environment
+  if (process.env.config) {
+    configLogger.info('Using config from environment')
+    try {
+      const config = internalContributionForksConfig.parse(
+        JSON.parse(process.env.config),
+      )
+      return config
+    } catch (e) {
+      configLogger.error('Invalid config found in environment!')
+      configLogger.error(e)
+      throw new Error(
+        'Invalid config found in environment! Please check the config file and error log for more details.',
+      )
+    }
+  }
+
+  // Fallback to pull from the .github repository if no orgId is provided
+
+  if (!orgId) {
+    logger.error(
+      'No orgId present, Organization ID is required to fetch a config when not using environment variables',
+    )
+    throw new Error('Organization ID is required to fetch a config!')
+  }
+
   const installationId = await appOctokit().rest.apps.getOrgInstallation({
     org: orgId,
   })

--- a/src/bot/config.ts
+++ b/src/bot/config.ts
@@ -1,0 +1,63 @@
+import { Configuration } from '@probot/octokit-plugin-config/dist-types/types'
+import { logger } from 'utils/logger'
+import z from 'zod'
+import { appOctokit, installationOctokit } from './octokit'
+
+const configLogger = logger.getSubLogger({ name: 'config' })
+
+const internalContributionForksConfig = z.object({
+  publicOrg: z.string(),
+  privateOrg: z.string(),
+})
+
+type InternalContributionForksConfig = z.infer<
+  typeof internalContributionForksConfig
+> &
+  Configuration
+
+/**
+ * Fetches a configuration file from the organization's .github repository
+ * @param orgId Organization ID
+ * @returns Configuration file
+ */
+export const getConfig = async (orgId: string) => {
+  const installationId = await appOctokit().rest.apps.getOrgInstallation({
+    org: orgId,
+  })
+  const octokit = installationOctokit(String(installationId.data.id))
+
+  const orgData = await octokit.rest.orgs.get({ org: orgId })
+
+  const config = await octokit.config.get<InternalContributionForksConfig>({
+    owner: orgData.data.login,
+    repo: '.github',
+    path: 'internal-contribution-forks/config.yml',
+  })
+
+  const found = Boolean(config.files[0].config)
+
+  if (!found) {
+    configLogger.warn(
+      `No config found for org, using default org: '${orgId}' for BOTH public and private!`,
+    )
+    return {
+      publicOrg: orgId,
+      privateOrg: orgId,
+    }
+  }
+
+  // Make sure config is valid
+  configLogger.info(`Found config file! Validating config for org: '${orgId}'`)
+  try {
+    internalContributionForksConfig.parse(config.config)
+    configLogger.info(`Config for org: '${orgId}' is valid!`)
+  } catch (e) {
+    configLogger.error(`Invalid config found for org: '${orgId}'!`)
+    configLogger.error(e)
+    throw new Error(
+      'Invalid config found! Please check the config file and error log for more details.',
+    )
+  }
+
+  return config.config
+}

--- a/src/bot/config.ts
+++ b/src/bot/config.ts
@@ -22,12 +22,13 @@ type InternalContributionForksConfig = z.infer<
  */
 export const getConfig = async (orgId?: string) => {
   // First check if there's a config file in the environment
-  if (process.env.config) {
-    configLogger.info('Using config from environment')
+  if (process.env.CONFIG) {
+    configLogger.info(`Using config from environment. Validating config file.`)
     try {
       const config = internalContributionForksConfig.parse(
-        JSON.parse(process.env.config),
+        JSON.parse(process.env.CONFIG!),
       )
+      configLogger.info('Config from environment is valid!')
       return config
     } catch (e) {
       configLogger.error('Invalid config found in environment!')

--- a/src/bot/octokit.ts
+++ b/src/bot/octokit.ts
@@ -1,6 +1,6 @@
 import { createAppAuth } from '@octokit/auth-app'
-import { Octokit } from 'octokit'
 import { logger } from 'utils/logger'
+import { Octokit } from './rest'
 
 const personalOctokitLogger = logger.getSubLogger({ name: 'personal-octokit' })
 const appOctokitLogger = logger.getSubLogger({ name: 'app-octokit' })

--- a/src/bot/rest.ts
+++ b/src/bot/rest.ts
@@ -1,0 +1,8 @@
+import { config } from '@probot/octokit-plugin-config'
+import { Octokit as Core } from 'octokit'
+
+export const Octokit = Core.plugin(config).defaults({
+  userAgent: `octokit-rest.js/repo-sync-bot`,
+})
+
+export type Octokit = InstanceType<typeof Octokit>

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -20,24 +20,8 @@ export const env = createEnv({
     WEBHOOK_PROXY_URL: z.string().url().optional(),
     LOG_LEVEL: z.string().optional().default('debug'),
     NODE_ENV: z.string().optional().default('development'),
-    CONFIG: z
-      .string()
-      .refine(
-        (value) => {
-          if (!value) return true
-
-          try {
-            JSON.parse(value)
-            return true
-          } catch (error) {
-            return false
-          }
-        },
-        {
-          message: 'CONFIG must be a valid JSON string',
-        },
-      )
-      .optional(),
+    PUBLIC_ORG: z.string().optional(),
+    PRIVATE_ORG: z.string().optional(),
   },
   /*
    * Environment variables available on the client (and server).
@@ -62,6 +46,7 @@ export const env = createEnv({
     WEBHOOK_PROXY_URL: process.env.WEBHOOK_PROXY_URL,
     LOG_LEVEL: process.env.LOG_LEVEL,
     NODE_ENV: process.env.NODE_ENV,
-    CONFIG: process.env.CONFIG,
+    PUBLIC_ORG: process.env.PUBLIC_ORG,
+    PRIVATE_ORG: process.env.PRIVATE_ORG,
   },
 })

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -1,0 +1,67 @@
+import { createEnv } from '@t3-oss/env-nextjs'
+import { z } from 'zod'
+
+export const env = createEnv({
+  /*
+   * Serverside Environment variables, not available on the client.
+   * Will throw if you access these variables on the client.
+   */
+  server: {
+    // Mandatory environment variables
+    APP_ID: z.string(),
+    GITHUB_CLIENT_ID: z.string(),
+    GITHUB_CLIENT_SECRET: z.string(),
+    NEXTAUTH_SECRET: z.string(),
+    NEXTAUTH_URL: z.string().url(),
+    WEBHOOK_SECRET: z.string(),
+    PRIVATE_KEY: z.string(),
+
+    // Optional environment variables
+    WEBHOOK_PROXY_URL: z.string().url().optional(),
+    LOG_LEVEL: z.string().optional().default('debug'),
+    NODE_ENV: z.string().optional().default('development'),
+    CONFIG: z
+      .string()
+      .refine(
+        (value) => {
+          if (!value) return true
+
+          try {
+            JSON.parse(value)
+            return true
+          } catch (error) {
+            return false
+          }
+        },
+        {
+          message: 'CONFIG must be a valid JSON string',
+        },
+      )
+      .optional(),
+  },
+  /*
+   * Environment variables available on the client (and server).
+   *
+   * 💡 You'll get type errors if these are not prefixed with NEXT_PUBLIC_.
+   */
+  client: {},
+  /*
+   * Due to how Next.js bundles environment variables on Edge and Client,
+   * we need to manually destructure them to make sure all are included in bundle.
+   *
+   * 💡 You'll get type errors if not all variables from `server` & `client` are included here.
+   */
+  runtimeEnv: {
+    APP_ID: process.env.APP_ID,
+    GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
+    GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
+    NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
+    NEXTAUTH_URL: process.env.NEXTAUTH_URL,
+    WEBHOOK_SECRET: process.env.WEBHOOK_SECRET,
+    PRIVATE_KEY: process.env.PRIVATE_KEY,
+    WEBHOOK_PROXY_URL: process.env.WEBHOOK_PROXY_URL,
+    LOG_LEVEL: process.env.LOG_LEVEL,
+    NODE_ENV: process.env.NODE_ENV,
+    CONFIG: process.env.CONFIG,
+  },
+})

--- a/src/pages/orgs/[organizationId]/forks/[forkId].tsx
+++ b/src/pages/orgs/[organizationId]/forks/[forkId].tsx
@@ -46,16 +46,20 @@ const SingleFork = (
     isLoading,
   } = trpc.git.createMirror.useMutation()
 
-  const { data: mirrors, isLoading: mirrorsLoading } =
-    trpc.repos.listMirrors.useQuery(
-      {
-        orgId: organizationId as string,
-        forkName: fork?.name as string,
-      },
-      {
-        enabled: !!organizationId && !!fork?.name,
-      },
-    )
+  const {
+    data: mirrors,
+    error: mirrorsError,
+    isLoading: mirrorsLoading,
+    refetch: refetchMirrors,
+  } = trpc.repos.listMirrors.useQuery(
+    {
+      orgId: organizationId as string,
+      forkName: fork?.name as string,
+    },
+    {
+      enabled: Boolean(organizationId) && Boolean(fork?.name),
+    },
+  )
 
   const loadAllData = useCallback(async () => {
     const orgInfo = await getOrgInformation(
@@ -81,6 +85,10 @@ const SingleFork = (
 
     loadAllData()
   }, [organizationId, accessToken, loadAllData])
+
+  useEffect(() => {
+    refetchMirrors()
+  }, [isOpen, refetchMirrors])
 
   const handleOnCreateMirror = useCallback(
     ({ repoName, branchName }: { repoName: string; branchName: string }) => {
@@ -170,6 +178,9 @@ const SingleFork = (
         {mirrorsLoading && <Box>Loading mirrors...</Box>}
         {mirrors && mirrors.items.length === 0 && (
           <Box>No mirrors found for this fork</Box>
+        )}
+        {mirrorsError && (
+          <Box>Failed to fetch mirrors. {mirrorsError?.message}</Box>
         )}
         <Box>
           {mirrors &&

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -1,10 +1,12 @@
 import { router } from '../trpc'
 import { gitRouter } from './git'
 import { octokitRouter } from './octokit'
+import { reposRouter } from './repos'
 
 export const appRouter = router({
   git: gitRouter,
   octokit: octokitRouter,
+  repos: reposRouter,
 })
 
 // export type definition of API

--- a/src/server/routers/repos.ts
+++ b/src/server/routers/repos.ts
@@ -1,4 +1,4 @@
-// This holds the elevated git permissions needed to run the app installation commands
+// This holds the elevated permissions to fetch data from the private org
 import { getConfig } from 'bot/config'
 import { appOctokit, installationOctokit } from 'bot/octokit'
 import { z } from 'zod'

--- a/src/server/routers/repos.ts
+++ b/src/server/routers/repos.ts
@@ -1,0 +1,38 @@
+// This holds the elevated git permissions needed to run the app installation commands
+import { getConfig } from 'bot/config'
+import { appOctokit, installationOctokit } from 'bot/octokit'
+import { z } from 'zod'
+import { procedure, router } from '../trpc'
+
+export const reposRouter = router({
+  // Queries
+  listMirrors: procedure
+    .input(
+      z.object({
+        orgId: z.string(),
+        forkName: z.string(),
+      }),
+    )
+    .query(async (opts) => {
+      const { orgId, forkName } = opts.input
+
+      const config = await getConfig(orgId)
+
+      const installationId = await appOctokit().rest.apps.getOrgInstallation({
+        org: config.privateOrg,
+      })
+
+      const octokit = installationOctokit(String(installationId.data.id))
+
+      const privateOrgData = await octokit.rest.orgs.get({
+        org: config.privateOrg,
+      })
+      const publicOrgData = await octokit.rest.orgs.get({ org: orgId })
+
+      const repos = await octokit.rest.search.repos({
+        q: `org:${privateOrgData.data.login} in:description "mirror:${publicOrgData.data.login}/${forkName}"`,
+      })
+
+      return repos.data
+    }),
+})

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,133 @@
+import * as config from '../src/bot/config'
+import { Octomock } from './octomock'
+const om = new Octomock()
+
+jest.mock('../src/bot/octokit', () => ({
+  generateAppAccessToken: async () => 'fake-token',
+  appOctokit: () => om.getOctokitImplementation(),
+  installationOctokit: () => om.getOctokitImplementation(),
+}))
+
+describe('ICF Config', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    delete process.env.PUBLIC_ORG
+    delete process.env.PRIVATE_ORG
+  })
+
+  it('should use env variables when they are available', async () => {
+    // set the env variables
+    process.env.PUBLIC_ORG = 'github'
+    process.env.PRIVATE_ORG = 'github-test'
+
+    const res = await config.getConfig()
+
+    expect(res).toEqual({
+      publicOrg: 'github',
+      privateOrg: 'github-test',
+    })
+  })
+
+  it('should use the public org for both values when only PUBLIC_ORG provided', async () => {
+    // set the env variables
+    process.env.PUBLIC_ORG = 'github'
+
+    const res = await config.getConfig()
+
+    expect(res).toEqual({
+      publicOrg: 'github',
+      privateOrg: 'github',
+    })
+  })
+
+  it('should throw an error when no env and no org id provided', async () => {
+    await config.getConfig().catch((error) => {
+      expect(error.message).toContain('Organization ID is required')
+    })
+  })
+
+  it('should fallback to github when an org id is provided', async () => {
+    om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue({
+      status: 200,
+      data: {
+        id: 12345,
+      },
+    })
+
+    om.mockFunctions.rest.orgs.get.mockResolvedValue({
+      status: 200,
+      data: {
+        login: 'github',
+      },
+    })
+
+    om.mockFunctions.config.get.mockResolvedValue({
+      files: [
+        {
+          config: {
+            publicOrg: 'github',
+            privateOrg: 'github-test',
+          },
+          path: 'internal-contribution-forks/config.yml',
+        },
+      ],
+      config: {
+        publicOrg: 'github',
+        privateOrg: 'github-test',
+      },
+    })
+
+    const res = await config.getConfig('12345')
+
+    expect(res).toEqual({
+      publicOrg: 'github',
+      privateOrg: 'github-test',
+    })
+
+    expect(om.mockFunctions.rest.apps.getOrgInstallation).toHaveBeenCalledTimes(
+      1,
+    )
+    expect(om.mockFunctions.rest.orgs.get).toHaveBeenCalledTimes(1)
+    expect(om.mockFunctions.config.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throw when an invalid config is pulled from github', async () => {
+    om.mockFunctions.rest.apps.getOrgInstallation.mockResolvedValue({
+      status: 200,
+      data: {
+        id: 12345,
+      },
+    })
+
+    om.mockFunctions.rest.orgs.get.mockResolvedValue({
+      status: 200,
+      data: {
+        login: 'github',
+      },
+    })
+
+    om.mockFunctions.config.get.mockResolvedValue({
+      files: [
+        {
+          config: {
+            invalid: 'config',
+          },
+          path: 'internal-contribution-forks/config.yml',
+        },
+      ],
+      config: {
+        invalid: 'config',
+      },
+    })
+
+    await config.getConfig('12345').catch((error) => {
+      expect(error.message).toContain('Invalid config')
+    })
+
+    expect(om.mockFunctions.rest.apps.getOrgInstallation).toHaveBeenCalledTimes(
+      1,
+    )
+    expect(om.mockFunctions.rest.orgs.get).toHaveBeenCalledTimes(1)
+    expect(om.mockFunctions.config.get).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/octomock/index.ts
+++ b/test/octomock/index.ts
@@ -1,6 +1,11 @@
 // This is taken from https://github.com/Chocrates/octomock
 
+const deepClone = (obj: unknown) => JSON.parse(JSON.stringify(obj))
+
 let mockFunctions = {
+  config: {
+    get: jest.fn(),
+  },
   rest: {
     apps: {
       getOrgInstallation: jest.fn(),
@@ -294,7 +299,10 @@ let mockFunctions = {
 }
 
 export class Octomock {
-  mockFunctions: { rest: Record<string, Record<string, jest.Mock>> }
+  mockFunctions: {
+    rest: Record<string, Record<string, jest.Mock>>
+    config: Record<string, jest.Mock>
+  }
   defaultContext: { payload: { issue: { body: string; user: {} } } }
 
   mockGitHubImplementation: {
@@ -383,11 +391,7 @@ export class Octomock {
   }
 
   resetMocks() {
-    for (let ctx in this.mockFunctions.rest) {
-      for (let func in this.mockFunctions.rest[ctx]) {
-        this.mockFunctions.rest[ctx][func].mockClear()
-      }
-    }
+    jest.resetAllMocks()
   }
 
   updateContext(context: {

--- a/test/octomock/index.ts
+++ b/test/octomock/index.ts
@@ -1,7 +1,5 @@
 // This is taken from https://github.com/Chocrates/octomock
 
-const deepClone = (obj: unknown) => JSON.parse(JSON.stringify(obj))
-
 let mockFunctions = {
   config: {
     get: jest.fn(),


### PR DESCRIPTION
This adds the ability to specify a different organization to hold mirrors into. This change requires the idea of a configuration to make this viable. This is done is a couple ways: through the `PUBLIC_ORG` and `PRIVATE_ORG` env variables, with a config file located in the public org's .github folder, or just not configuring it at all. 

Everything will still work as before. 

This also adds env file checking at runtime and throws an error when there is a misconfiguration

addresses #12

Documentation will be a follow up PR as no breaking changes are being introduced and all code is backwards compatible