### PR TITLE
Disable payload parsing on webhook endpoint

### DIFF
--- a/src/pages/api/webhooks.ts
+++ b/src/pages/api/webhooks.ts
@@ -4,6 +4,14 @@ import { logger } from 'utils/logger'
 
 export const probot = createProbot()
 
+// Disable the bodyParser to allow the raw body to be read
+// https://github.com/github-community-projects/internal-contribution-forks/issues/88
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+}
+
 export default createNodeMiddleware(app, {
   probot: createProbot({
     defaults: {


### PR DESCRIPTION
This fixes an issue when we upgraded to probot 13

fixes https://github.com/github-community-projects/internal-contribution-forks/issues/88

