### PR TITLE
feat: release on specific labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,9 +35,9 @@ version-resolver:
   minor:
     labels:
       - 'enhancement'
+      - 'fix'
   patch:
     labels:
-      - 'fix'
       - 'documentation'
       - 'maintenance'
   default: patch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: Release
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - main
 
@@ -12,6 +14,16 @@ permissions:
 
 jobs:
   create_release:
+    # release if
+    # manual deployment OR
+    # merged to main and labelled with release labels
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true &&
+      (contains(github.event.pull_request.labels.*.name, 'breaking') ||
+      contains(github.event.pull_request.labels.*.name, 'enhancement') ||
+      contains(github.event.pull_request.labels.*.name, 'vuln') ||
+      contains(github.event.pull_request.labels.*.name, 'release')))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,12 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
+## Releases
+
+Releases are automated if a pull request is labelled with our [semver related labels](.github/release-drafter.yml) or with the `vuln` or `release` labels.
+
+You can also manually initiate a release you can do so through the GitHub Actions UI. If you have permissions to do so, you can navigate to the [Actions tab](https://github.com/github-community-projects/internal-contribution-forks/actions/workflows/release.yml) and select the `Run workflow` button. This will allow you to select the branch to release from and the version to release.
+
 ## Resources
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)


### PR DESCRIPTION
Related to https://github.com/github/github-ospo/issues/105

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Only generate a release if our semver related labels (`breaking`, `enhancement`, `fix`) or the `release` label are present on a merged pull request.

Changed from push (merge) on main branch to release generation happening when a pull_request is merged to main branch.

This gives us access to the pull requests labels without having to make API cals.

Currently we'd still need to label a pull request with `release` if it is a dependabot or manual pull request related to a CVE or security fix.

- [x] update CONTRIBUTING.md with new release information
- [x] manually add `vuln` and `release` labels to repository

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
