### PR TITLE
fix: cleanup the private mirror if it fails to create

### DIFF
--- a/src/server/routers/git.ts
+++ b/src/server/routers/git.ts
@@ -275,9 +275,9 @@ export const gitRouter = router({
           data: newRepo.data,
         }
       } catch (e) {
-        // Clean up the repo made
+        // Clean up the private mirror repo made
         await privateOctokit.rest.repos.delete({
-          owner: orgData.data.login,
+          owner: privateOrg,
           repo: opts.input.newRepoName,
         })
 


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

Since switching to a dual tenant model, we need to be explicit about which repo we want to delete on mirror creation failures. This fixes that. 

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
