### PR TITLE
fix: Disable Global Git Hooks in Simple Git

### DIFF
--- a/src/server/routers/git.ts
+++ b/src/server/routers/git.ts
@@ -91,6 +91,8 @@ export const gitRouter = router({
         config: [
           `user.name=internal-contribution-forks[bot]`,
           `user.email=${privateInstallationId}+internal-contribution-forks[bot]@users.noreply.github.com`,
+          // Disable any global git hooks to prevent potential interference when running the app locally
+          'core.hooksPath=/dev/null',
         ],
       }
 
@@ -214,6 +216,8 @@ export const gitRouter = router({
             `user.name=internal-contribution-forks[bot]`,
             // We want to use the private installation ID as the email so that we can push to the private repo
             `user.email=${privateInstallationId}+internal-contribution-forks[bot]@users.noreply.github.com`,
+            // Disable any global git hooks to prevent potential interference when running the app locally
+            'core.hooksPath=/dev/null',
           ],
         }
         const git = simpleGit(tempDir, options)


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
Adds a config option to Simple Git which disables the running of global git hooks which may be triggered when running ICF locally. In some testing of the app, unrelated git hooks on my machine caused failures in the app which can be avoided using this flag.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
