### PR TITLE
chore: remove pull_request target if we already have pull_request_target

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -2,11 +2,7 @@
 name: Auto Labeler
 
 on:
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target event is required for autolabeler to support all PRs including forks
   pull_request_target:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CodeQL](https://github.com/github-community-projects/internal-contribution-forks/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/github-community-projects/internal-contribution-forks/actions/workflows/github-code-scanning/codeql)
 [![Docker Build](https://github.com/github-community-projects/internal-contribution-forks/actions/workflows/docker-build.yml/badge.svg)](https://github.com/github-community-projects/internal-contribution-forks/actions/workflows/docker-build.yml)
 [![Lint](https://github.com/github-community-projects/internal-contribution-forks/actions/workflows/lint.yml/badge.svg)](https://github.com/github-community-projects/internal-contribution-forks/actions/workflows/lint.yml)
 [![Tests](https://github.com/github-community-projects/internal-contribution-forks/actions/workflows/tests.yml/badge.svg)](https://github.com/github-community-projects/internal-contribution-forks/actions/workflows/tests.yml)


### PR DESCRIPTION
We learned that release will run twice if `pull_request_target` target is on a GitHub Action, if `pull_request` target is alson on the action.  We need `pull_request_target` action to allow us to detect the labels on forked pull requests.  Auto labeller action has same problem.  This change prevents the double runs.

# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

- [x] auto-labeler action
- [x] release action
- [x] add CODEQL badge to README

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `npm run lint` and fix any linting issues that have been introduced
- [ ] run `npm run test` and run tests

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
