### PR TITLE
chore: change from only security updates to grouping 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,22 +4,30 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    # limit to only security updates
-    open-pull-requests-limit: 0
     commit-message:
       prefix: 'chore'
       prefix-development: 'chore'
       include: 'scope'
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
       interval: 'weekly'
-    # limit to only security updates
-    open-pull-requests-limit: 0
     commit-message:
       prefix: 'chore'
       prefix-development: 'chore'
       include: 'scope'
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    # limit to only security updates
+    open-pull-requests-limit: 0
     commit-message:
       prefix: 'chore'
       prefix-development: 'chore'
@@ -12,6 +14,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    # limit to only security updates
+    open-pull-requests-limit: 0
     commit-message:
       prefix: 'chore'
       prefix-development: 'chore'
@@ -24,3 +28,9 @@ updates:
       prefix: 'chore'
       prefix-development: 'chore'
       include: 'scope'
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

- [x] gonna try grouping first to see if that reduces the PR spam
- [x] allow updates to github actions dependencies but group minor and patch updates

If grouping doesn't reduce PR spam we'll look at limiting npm and docker dependencies to only security updates
  - [docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#:~:text=If%20you%20only%20require%20security%20updates%20and%20want%20to%20exclude%20version%20updates%2C%20you%20can%20set%20open%2Dpull%2Drequests%2Dlimit%20to%200%20in%20order%20to%20prevent%20version%20updates%20for%20a%20given%20package%2Decosystem.)

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
