### PR TITLE
fix: middleware race condition when checking auth validity

### DIFF
--- a/src/server/git/router.ts
+++ b/src/server/git/router.ts
@@ -1,9 +1,9 @@
-import { procedure, router } from '../../utils/trpc-server'
+import { gitProcedure, router } from '../../utils/trpc-server'
 import { syncReposHandler } from './controller'
 import { SyncReposSchema } from './schema'
 
 const gitRouter = router({
-  syncRepos: procedure
+  syncRepos: gitProcedure
     .input(SyncReposSchema)
     .mutation(({ input }) => syncReposHandler({ input })),
 })

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -43,12 +43,19 @@ export const checkGitHubAppInstallationAuth = async (
 
   const octokit = personalOctokit(accessToken)
 
-  const data = await octokit.rest.repos.get({
-    owner: mirrorOrgOwner,
-    repo: mirrorRepo,
-  })
+  const data = await octokit.rest.repos
+    .get({
+      owner: mirrorOrgOwner,
+      repo: mirrorRepo,
+    })
+    .catch((error) => {
+      middlewareLogger.error('Error checking github app installation auth', {
+        error,
+      })
+      return null
+    })
 
-  if (!data.data) {
+  if (!data?.data) {
     middlewareLogger.error('App does not have access to mirror repo')
     throw new TRPCError({ code: 'UNAUTHORIZED' })
   }

--- a/src/utils/trpc-middleware.ts
+++ b/src/utils/trpc-middleware.ts
@@ -1,4 +1,3 @@
-import { TRPCError } from '@trpc/server'
 import { checkGitHubAppInstallationAuth, checkGitHubAuth } from './auth'
 import { Middleware } from './trpc-server'
 
@@ -6,20 +5,15 @@ export const verifyGitHubAppAuth: Middleware = async (opts) => {
   const { ctx, rawInput } = opts
 
   // Check app authentication
-  try {
-    await checkGitHubAppInstallationAuth(
-      (rawInput as Record<string, string>)?.accessToken,
-      (rawInput as Record<string, string>)?.mirrorOwner,
-      (rawInput as Record<string, string>)?.mirrorName,
-    )
+  await checkGitHubAppInstallationAuth(
+    (rawInput as Record<string, string>)?.accessToken,
+    (rawInput as Record<string, string>)?.mirrorOwner,
+    (rawInput as Record<string, string>)?.mirrorName,
+  )
 
-    return opts.next({
-      ctx,
-    })
-  } catch (error) {
-    console.error('Error checking github app installation auth', error)
-    throw new TRPCError({ code: 'UNAUTHORIZED' })
-  }
+  return opts.next({
+    ctx,
+  })
 }
 
 export const verifyAuth: Middleware = async (opts) => {

--- a/src/utils/trpc-server.ts
+++ b/src/utils/trpc-server.ts
@@ -1,9 +1,9 @@
 import { initTRPC } from '@trpc/server'
 import { CreateNextContextOptions } from '@trpc/server/adapters/next'
 import { getServerSession } from 'next-auth'
-import { nextAuthOptions } from '../app/api/auth/lib/nextauth-options'
-import { verifyAuth } from '../utils/trpc-middleware'
 import SuperJSON from 'superjson'
+import { nextAuthOptions } from '../app/api/auth/lib/nextauth-options'
+import { verifyAuth, verifyGitHubAppAuth } from '../utils/trpc-middleware'
 
 export const createContext = async (opts: CreateNextContextOptions) => {
   const session = await getServerSession(opts.req, opts.res, nextAuthOptions)
@@ -23,5 +23,9 @@ export const t = initTRPC.context<typeof createContext>().create({
 
 // Base router and procedure helpers
 export const router = t.router
+const publicProcedure = t.procedure
 export type Middleware = Parameters<(typeof t.procedure)['use']>[0]
-export const procedure = t.procedure.use(verifyAuth)
+// Used for general user access token verification
+export const procedure = publicProcedure.use(verifyAuth)
+// Used for GitHub App authentication verification (non-user events like 'push')
+export const gitProcedure = publicProcedure.use(verifyGitHubAppAuth)


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

There was a missing `await` that caused a race condition in our trpc auth middleware. We would throw an authorization error _after_ we already called `next` on the middleware. 

This corrects that and fixes the auth.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
