### PR TITLE
feat: add stricter eslint rules for typescript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,17 +8,11 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "parserOptions": {
-    "project": ["./tsconfig.json"] // Specify it only for TypeScript files
-    // or `project: true` in typescript-eslint version >= 5.52.0
+    "project": ["./tsconfig.json"]
   },
   "root": true,
   "rules": {
-    "@typescript-eslint/no-unsafe-member-access": "warn",
-    "@typescript-eslint/no-unsafe-assignment": "warn",
-    "@typescript-eslint/no-explicit-any": "warn",
-    "@typescript-eslint/no-unsafe-call": "warn",
-    "@typescript-eslint/no-unsafe-argument": "warn",
-    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
-    "@typescript-eslint/no-floating-promises": "warn"
+    // Most of the problems this rule catches are false positives from libs
+    "@typescript-eslint/no-misused-promises": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,24 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": [
+    "next/core-web-vitals",
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-type-checked"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "parserOptions": {
+    "project": ["./tsconfig.json"] // Specify it only for TypeScript files
+    // or `project: true` in typescript-eslint version >= 5.52.0
+  },
+  "root": true,
+  "rules": {
+    "@typescript-eslint/no-unsafe-member-access": "warn",
+    "@typescript-eslint/no-unsafe-assignment": "warn",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unsafe-call": "warn",
+    "@typescript-eslint/no-unsafe-argument": "warn",
+    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+    "@typescript-eslint/no-floating-promises": "warn"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,15 +36,19 @@
       },
       "devDependencies": {
         "@babel/preset-env": "7.24.5",
+        "@eslint/js": "^9.4.0",
         "@tanstack/eslint-plugin-query": "5.35.6",
+        "@types/eslint__js": "^8.42.3",
         "@types/jest": "29.5.12",
         "@types/node": "20.12.12",
         "@types/node-fetch": "2.6.11",
         "@types/react": "18.3.2",
+        "@typescript-eslint/eslint-plugin": "^7.13.0",
+        "@typescript-eslint/parser": "^7.13.0",
         "babel-jest": "29.7.0",
         "concurrently": "8.2.2",
         "dotenv-load": "3.0.0",
-        "eslint": "8.57.0",
+        "eslint": "^8.57.0",
         "eslint-config-next": "14.2.3",
         "github-app-webhook-relay-polling": "1.1.0",
         "husky": "9.0.11",
@@ -54,7 +58,8 @@
         "prettier": "3.2.5",
         "ts-jest": "29.1.2",
         "ts-node": "10.9.2",
-        "typescript": "5.4.5"
+        "typescript": "^5.4.5",
+        "typescript-eslint": "^7.13.0"
       },
       "engines": {
         "node": ">= 18"
@@ -2063,12 +2068,12 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.4.0.tgz",
+      "integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
       "dev": true,
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@github/combobox-nav": {
@@ -4152,6 +4157,31 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/eslint": {
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint__js": {
+      "version": "8.42.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-8.42.3.tgz",
+      "integrity": "sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
     "node_modules/@types/express": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
@@ -4427,6 +4457,213 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.0.tgz",
+      "integrity": "sha512-FX1X6AF0w8MdVFLSdqwqN/me2hyhuQg4ykN6ZpVhh1ij/80pTvDKclX1sZB9iqex8SjQfVhwMKs3JtnnMLzG9w==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.13.0",
+        "@typescript-eslint/type-utils": "7.13.0",
+        "@typescript-eslint/utils": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
+      "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
+      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.0.tgz",
+      "integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.13.0",
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/typescript-estree": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
+      "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
+      "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
+      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
@@ -4442,6 +4679,115 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.0.tgz",
+      "integrity": "sha512-xMEtMzxq9eRkZy48XuxlBFzpVMDurUAfDu5Rz16GouAtXm0TaAoTFzqWUFPPuQYXI/CDaH/Bgx/fk/84t/Bc9A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.13.0",
+        "@typescript-eslint/utils": "7.13.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
+      "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
+      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -4498,6 +4844,127 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
+      "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.13.0",
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/typescript-estree": "7.13.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
+      "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
+      "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
+      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.13.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -6985,6 +7452,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/eslint/node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -8282,9 +8758,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "engines": {
         "node": ">= 4"
       }
@@ -12849,34 +13325,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -14014,6 +14471,32 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.13.0.tgz",
+      "integrity": "sha512-upO0AXxyBwJ4BbiC6CRgAJKtGYha2zw4m1g7TIVPSonwYEuf7vCicw3syjS1OxdDMTz96sZIXl3Jx3vWJLLKFw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "7.13.0",
+        "@typescript-eslint/parser": "7.13.0",
+        "@typescript-eslint/utils": "7.13.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,19 +36,17 @@
       },
       "devDependencies": {
         "@babel/preset-env": "7.24.5",
-        "@eslint/js": "^9.4.0",
         "@tanstack/eslint-plugin-query": "5.35.6",
-        "@types/eslint__js": "^8.42.3",
         "@types/jest": "29.5.12",
         "@types/node": "20.12.12",
         "@types/node-fetch": "2.6.11",
         "@types/react": "18.3.2",
-        "@typescript-eslint/eslint-plugin": "^7.13.0",
-        "@typescript-eslint/parser": "^7.13.0",
+        "@typescript-eslint/eslint-plugin": "7.13.0",
+        "@typescript-eslint/parser": "7.13.0",
         "babel-jest": "29.7.0",
         "concurrently": "8.2.2",
         "dotenv-load": "3.0.0",
-        "eslint": "^8.57.0",
+        "eslint": "8.57.0",
         "eslint-config-next": "14.2.3",
         "github-app-webhook-relay-polling": "1.1.0",
         "husky": "9.0.11",
@@ -58,8 +56,8 @@
         "prettier": "3.2.5",
         "ts-jest": "29.1.2",
         "ts-node": "10.9.2",
-        "typescript": "^5.4.5",
-        "typescript-eslint": "^7.13.0"
+        "typescript": "5.4.5",
+        "typescript-eslint": "7.13.0"
       },
       "engines": {
         "node": ">= 18"
@@ -2065,15 +2063,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.4.0.tgz",
-      "integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@github/combobox-nav": {
@@ -4156,31 +4145,6 @@
       "dependencies": {
         "@types/ms": "*"
       }
-    },
-    "node_modules/@types/eslint": {
-      "version": "8.56.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint__js": {
-      "version": "8.42.3",
-      "resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-8.42.3.tgz",
-      "integrity": "sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
     },
     "node_modules/@types/express": {
       "version": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -46,19 +46,17 @@
   },
   "devDependencies": {
     "@babel/preset-env": "7.24.5",
-    "@eslint/js": "^9.4.0",
     "@tanstack/eslint-plugin-query": "5.35.6",
-    "@types/eslint__js": "^8.42.3",
     "@types/jest": "29.5.12",
     "@types/node": "20.12.12",
     "@types/node-fetch": "2.6.11",
     "@types/react": "18.3.2",
-    "@typescript-eslint/eslint-plugin": "^7.13.0",
-    "@typescript-eslint/parser": "^7.13.0",
+    "@typescript-eslint/eslint-plugin": "7.13.0",
+    "@typescript-eslint/parser": "7.13.0",
     "babel-jest": "29.7.0",
     "concurrently": "8.2.2",
     "dotenv-load": "3.0.0",
-    "eslint": "^8.57.0",
+    "eslint": "8.57.0",
     "eslint-config-next": "14.2.3",
     "github-app-webhook-relay-polling": "1.1.0",
     "husky": "9.0.11",
@@ -68,8 +66,8 @@
     "prettier": "3.2.5",
     "ts-jest": "29.1.2",
     "ts-node": "10.9.2",
-    "typescript": "^5.4.5",
-    "typescript-eslint": "^7.13.0"
+    "typescript": "5.4.5",
+    "typescript-eslint": "7.13.0"
   },
   "engines": {
     "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -46,15 +46,19 @@
   },
   "devDependencies": {
     "@babel/preset-env": "7.24.5",
+    "@eslint/js": "^9.4.0",
     "@tanstack/eslint-plugin-query": "5.35.6",
+    "@types/eslint__js": "^8.42.3",
     "@types/jest": "29.5.12",
     "@types/node": "20.12.12",
     "@types/node-fetch": "2.6.11",
     "@types/react": "18.3.2",
+    "@typescript-eslint/eslint-plugin": "^7.13.0",
+    "@typescript-eslint/parser": "^7.13.0",
     "babel-jest": "29.7.0",
     "concurrently": "8.2.2",
     "dotenv-load": "3.0.0",
-    "eslint": "8.57.0",
+    "eslint": "^8.57.0",
     "eslint-config-next": "14.2.3",
     "github-app-webhook-relay-polling": "1.1.0",
     "husky": "9.0.11",
@@ -64,7 +68,8 @@
     "prettier": "3.2.5",
     "ts-jest": "29.1.2",
     "ts-node": "10.9.2",
-    "typescript": "5.4.5"
+    "typescript": "^5.4.5",
+    "typescript-eslint": "^7.13.0"
   },
   "engines": {
     "node": ">= 18"

--- a/src/app/[organizationId]/forks/[forkId]/page.tsx
+++ b/src/app/[organizationId]/forks/[forkId]/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 'use client'
 
 import { useParams } from 'next/navigation'
@@ -21,23 +22,23 @@ import {
 import Blankslate from '@primer/react/lib-esm/Blankslate/Blankslate'
 import { DataTable, Table } from '@primer/react/lib-esm/DataTable'
 import { Stack } from '@primer/react/lib-esm/Stack'
+import { ForkBreadcrumbs } from 'app/components/breadcrumbs/ForkBreadcrumbs'
+import { CreateMirrorDialog } from 'app/components/dialog/CreateMirrorDialog'
+import { DeleteMirrorDialog } from 'app/components/dialog/DeleteMirrorDialog'
+import { EditMirrorDialog } from 'app/components/dialog/EditMirrorDialog'
 import { AppNotInstalledFlash } from 'app/components/flash/AppNotInstalledFlash'
+import { ErrorFlash } from 'app/components/flash/ErrorFlash'
+import { SuccessFlash } from 'app/components/flash/SuccessFlash'
+import { ForkHeader } from 'app/components/header/ForkHeader'
+import { Loading } from 'app/components/loading/Loading'
 import { SearchWithCreate } from 'app/components/search/SearchWithCreate'
+import Fuse from 'fuse.js'
 import { useForkData } from 'hooks/useFork'
 import { useOrgData } from 'hooks/useOrganization'
 import { useCallback, useState } from 'react'
-import { ForkBreadcrumbs } from 'app/components/breadcrumbs/ForkBreadcrumbs'
-import { DeleteMirrorDialog } from 'app/components/dialog/DeleteMirrorDialog'
-import { CreateMirrorDialog } from 'app/components/dialog/CreateMirrorDialog'
-import { SuccessFlash } from 'app/components/flash/SuccessFlash'
-import { Loading } from 'app/components/loading/Loading'
-import { ErrorFlash } from 'app/components/flash/ErrorFlash'
-import { EditMirrorDialog } from 'app/components/dialog/EditMirrorDialog'
-import Fuse from 'fuse.js'
-import { ForkHeader } from 'app/components/header/ForkHeader'
 
 const Fork = () => {
-  const { organizationId, forkId } = useParams()
+  const { organizationId } = useParams()
   const { data, isLoading } = trpc.checkInstallation.useQuery({
     orgId: organizationId as string,
   })

--- a/src/app/api/auth/[...nextauth]/route.tsx
+++ b/src/app/api/auth/[...nextauth]/route.tsx
@@ -1,6 +1,10 @@
 import NextAuth from 'next-auth'
+import { NextRequest, NextResponse } from 'next/server'
 import { nextAuthOptions } from '../lib/nextauth-options'
 
-const handler = NextAuth(nextAuthOptions)
+const handler = NextAuth(nextAuthOptions) as (
+  req: NextRequest,
+  res: NextResponse,
+) => Promise<void>
 
 export { handler as GET, handler as POST }

--- a/src/app/api/trpc/trpc-router.ts
+++ b/src/app/api/trpc/trpc-router.ts
@@ -1,10 +1,10 @@
 import gitRouter from '../../../server/git/router'
 import octokitRouter from '../../../server/octokit/router'
 import reposRouter from '../../../server/repos/router'
-import { t, procedure } from '../../../utils/trpc-server'
+import { procedure, t } from '../../../utils/trpc-server'
 
 export const healthCheckerRouter = t.router({
-  healthChecker: procedure.query(({}) => {
+  healthChecker: procedure.query(() => {
     return 'ok'
   }),
 })

--- a/src/app/components/flash/AppNotInstalledFlash.tsx
+++ b/src/app/components/flash/AppNotInstalledFlash.tsx
@@ -1,6 +1,5 @@
 import { AlertIcon } from '@primer/octicons-react'
 import { Box, Flash, Link, Octicon } from '@primer/react'
-import { OrgData } from 'hooks/useOrganization'
 
 interface AppNotInstalledFlashProps {
   orgLogin: string

--- a/src/app/components/header/MainHeader.tsx
+++ b/src/app/components/header/MainHeader.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 'use client'
 
 import { MarkGithubIcon } from '@primer/octicons-react'

--- a/src/app/components/header/WelcomeHeader.tsx
+++ b/src/app/components/header/WelcomeHeader.tsx
@@ -1,5 +1,5 @@
-import { BugIcon, GitBranchIcon, RepoForkedIcon } from '@primer/octicons-react'
-import { Avatar, Octicon, Pagehead, Text } from '@primer/react'
+import { RepoForkedIcon } from '@primer/octicons-react'
+import { Octicon, Pagehead, Text } from '@primer/react'
 import { Stack } from '@primer/react/lib-esm/Stack'
 
 export const WelcomeHeader = () => {

--- a/src/app/context/AuthProvider.tsx
+++ b/src/app/context/AuthProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 'use client'
 
 import { Session } from 'next-auth'

--- a/src/bot/config.ts
+++ b/src/bot/config.ts
@@ -42,8 +42,8 @@ export const getEnvConfig = () => {
   )
 
   const config = {
-    publicOrg: process.env.PUBLIC_ORG as string,
-    privateOrg: process.env.PUBLIC_ORG as string,
+    publicOrg: process.env.PUBLIC_ORG,
+    privateOrg: process.env.PUBLIC_ORG,
   } as InternalContributionForksConfig
 
   if (process.env.PRIVATE_ORG) {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -9,12 +9,14 @@ type CustomProperties = Record<string, string>
 const botLogger = logger.getSubLogger({ name: 'bot' })
 
 // Helper function to get the fork name from the repository custom properties
-export const getForkName = async (props: CustomProperties) => {
+export const getForkName = (props: CustomProperties) => {
   return props.fork ?? null
 }
 
 // Helper function to get the metadata from the repository description
-export const getMetadata = (description: string | null) => {
+export const getMetadata = (
+  description: string | null,
+): Record<string, string> => {
   botLogger.debug('Getting metadata from repository description', {
     description,
   })
@@ -24,7 +26,7 @@ export const getMetadata = (description: string | null) => {
   }
 
   try {
-    return JSON.parse(description)
+    return JSON.parse(description) as Record<string, string>
   } catch (error) {
     botLogger.warn('Failed to parse repository description', { description })
     return {}
@@ -33,12 +35,12 @@ export const getMetadata = (description: string | null) => {
 
 function bot(app: Probot) {
   // Catch-all to log all webhook events
-  app.onAny(async (context) => {
+  app.onAny((context) => {
     botLogger.debug('Received webhook event `onAny`', { event: context.name })
   })
 
   // Good for debugging :)
-  app.on('ping', async (_) => {
+  app.on('ping', () => {
     botLogger.debug('pong')
   })
 
@@ -62,7 +64,7 @@ function bot(app: Probot) {
     }
 
     // Check repo properties to see if this is a mirror
-    const forkNameWithOwner = await getForkName(
+    const forkNameWithOwner = getForkName(
       (
         context.payload.repository as typeof context.payload.repository & {
           custom_properties: CustomProperties
@@ -118,7 +120,7 @@ function bot(app: Probot) {
     }
 
     // Check repo properties to see if this is a mirror
-    const forkNameWithOwner = await getForkName(
+    const forkNameWithOwner = getForkName(
       (
         context.payload.repository as typeof context.payload.repository & {
           custom_properties: CustomProperties
@@ -160,7 +162,7 @@ function bot(app: Probot) {
     botLogger.info('Push event')
 
     // Check repo properties to see if this is a mirror
-    const forkNameWithOwner = await getForkName(
+    const forkNameWithOwner = getForkName(
       (
         context.payload.repository as typeof context.payload.repository & {
           custom_properties: CustomProperties
@@ -224,7 +226,7 @@ function bot(app: Probot) {
         mirrorOwner,
         orgId,
       })
-      .catch((error) => {
+      .catch((error: Error) => {
         botLogger.error('Failed to sync repository', { error })
       })
 

--- a/src/bot/octokit.ts
+++ b/src/bot/octokit.ts
@@ -8,7 +8,7 @@ const appOctokitLogger = logger.getSubLogger({ name: 'app-octokit' })
 
 // This is a bug with the way the private key is stored in the docker env
 // See https://github.com/moby/moby/issues/46773
-let privateKey = process.env.PRIVATE_KEY?.includes('\\n')
+const privateKey = process.env.PRIVATE_KEY?.includes('\\n')
   ? process.env.PRIVATE_KEY.replace(/\\n/g, '\n')
   : process.env.PRIVATE_KEY!
 

--- a/src/hooks/useFork.tsx
+++ b/src/hooks/useFork.tsx
@@ -1,21 +1,17 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { personalOctokit } from 'bot/octokit'
 import { useSession } from 'next-auth/react'
 import { useParams } from 'next/navigation'
 import { Octokit } from 'octokit'
 import { useEffect, useState } from 'react'
 
-const getForkById = async (
-  accessToken: string,
-  repoId: string,
-): Promise<
-  Awaited<ReturnType<Octokit['rest']['repos']['get']>>['data'] | null
-> => {
+const getForkById = async (accessToken: string, repoId: string) => {
   try {
     return (
       await personalOctokit(accessToken).request('GET /repositories/:id', {
         id: repoId,
       })
-    ).data
+    ).data as Awaited<ReturnType<Octokit['rest']['repos']['get']>>['data']
   } catch (error) {
     console.error('Error fetching fork', { error })
     return null

--- a/src/hooks/useForks.tsx
+++ b/src/hooks/useForks.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { getReposInOrgGQL } from 'bot/graphql'
 import { personalOctokit } from 'bot/octokit'
 import { useSession } from 'next-auth/react'
@@ -13,9 +14,9 @@ const getForksInOrg = async (accessToken: string, login: string) => {
       login,
       isFork: true,
     })
-    .catch((err) => {
-      forksLogger.error('Error fetching forks', { err })
-      return err.data as ForksObject
+    .catch((error: Error & { data: ForksObject }) => {
+      forksLogger.error('Error fetching forks', { error })
+      return error.data
     })
 
   // the primer datatable component requires the data to not contain null
@@ -43,7 +44,7 @@ const getForksInOrg = async (accessToken: string, login: string) => {
           languages: {
             nodes: node.languages.nodes.map((node) => ({
               name: node.name,
-              color: node.color as string,
+              color: node.color,
             })),
           },
           refs: {

--- a/src/hooks/useOrganization.tsx
+++ b/src/hooks/useOrganization.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { personalOctokit } from 'bot/octokit'
 import { useSession } from 'next-auth/react'
 import { useParams, useRouter } from 'next/navigation'

--- a/src/hooks/useOrganizations.tsx
+++ b/src/hooks/useOrganizations.tsx
@@ -29,7 +29,7 @@ export const useOrgsData = () => {
       .then((orgs) => {
         setOrganizationData(orgs.data)
       })
-      .catch((error) => {
+      .catch((error: Error) => {
         setError(error)
       })
       .finally(() => {

--- a/src/pages/api/webhooks.ts
+++ b/src/pages/api/webhooks.ts
@@ -15,8 +15,10 @@ export const config = {
 export default createNodeMiddleware(app, {
   probot: createProbot({
     defaults: {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       log: {
         child: () => probotLogger,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any,
     },
   }),

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -48,7 +48,7 @@ export const checkGitHubAppInstallationAuth = async (
       owner: mirrorOrgOwner,
       repo: mirrorRepo,
     })
-    .catch((error) => {
+    .catch((error: Error) => {
       middlewareLogger.error('Error checking github app installation auth', {
         error,
       })

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Logger } from 'tslog'
 
 // If you need logs during tests you can set the env var TEST_LOGGING=true
@@ -20,14 +21,22 @@ export const logger = new Logger({
     /(?<=:\/\/)([^:]+):([^@]+)(?=@)/g,
   ],
   overwrite: {
-    transportJSON: (logObjWithMeta: any) => {
+    transportJSON: (log) => {
+      let logObjWithMeta = log as {
+        _meta?: Record<string, any>
+        meta?: Record<string, any>
+        message?: string
+        data?: Record<string, any>
+        [key: string]: any
+      }
+
       const meta = logObjWithMeta._meta
 
       delete logObjWithMeta._meta
 
       // If the log is only a string, then set "message"
       if (
-        logObjWithMeta.hasOwnProperty('0') &&
+        Object.prototype.hasOwnProperty.call(logObjWithMeta, '0') &&
         typeof logObjWithMeta['0'] === 'string'
       ) {
         const message = logObjWithMeta['0']
@@ -44,7 +53,7 @@ export const logger = new Logger({
         }
       }
 
-      if (Object.keys(logObjWithMeta.data).length === 0) {
+      if (Object.keys(logObjWithMeta.data ?? {}).length === 0) {
         delete logObjWithMeta.data
       }
 


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

While we were pairing on https://github.com/github-community-projects/internal-contribution-forks/pull/162, we found that we didn't add an `await` keyword to the function running the auth check. To prevent this from happening in the future, I added stricter eslint rules for typescript

This also fixes all the problems that arise from the addition of these rules. In general, we're looking pretty good 🥨 

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
