### PR TITLE
fix: stringify json logging to be single line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@trpc/client": "10.45.2",
         "@trpc/react-query": "10.45.2",
         "@trpc/server": "10.45.2",
+        "fast-safe-stringify": "2.1.1",
         "fuse.js": "7.0.0",
         "next": "14.2.3",
         "next-auth": "4.24.7",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@trpc/client": "10.45.2",
     "@trpc/react-query": "10.45.2",
     "@trpc/server": "10.45.2",
+    "fast-safe-stringify": "2.1.1",
     "fuse.js": "7.0.0",
     "next": "14.2.3",
     "next-auth": "4.24.7",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import safeStringify from 'fast-safe-stringify'
 import { Logger } from 'tslog'
+
+// This is a workaround for the issue with JSON.stringify and circular references
+const stringify = (obj: any) => {
+  try {
+    return JSON.stringify(obj)
+  } catch (e) {
+    return safeStringify(obj)
+  }
+}
 
 // If you need logs during tests you can set the env var TEST_LOGGING=true
 const getLoggerType = () => {
@@ -60,7 +70,7 @@ export const logger = new Logger({
         output.data = logObjWithMeta['1']
       }
 
-      console.log(output)
+      console.log(stringify(output))
     },
   },
 })


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

`console.log` makes object appear on multiple lines. This adds support for a single line to be picked up by json by using stringify

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
