### PR TITLE
fix: Enforce repository name length limit in dialogs

### DIFF
--- a/src/app/components/dialog/CreateMirrorDialog.tsx
+++ b/src/app/components/dialog/CreateMirrorDialog.tsx
@@ -63,6 +63,7 @@ export const CreateMirrorDialog = ({
             onChange={(e) => setRepoName(e.target.value)}
             block
             placeholder="e.g. repository-name"
+            maxLength={100}
           />
           <FormControl.Caption>
             This is a private mirror of{' '}

--- a/src/app/components/dialog/EditMirrorDialog.tsx
+++ b/src/app/components/dialog/EditMirrorDialog.tsx
@@ -75,6 +75,7 @@ export const EditMirrorDialog = ({
             onChange={(e) => setNewMirrorName(e.target.value)}
             block
             placeholder="e.g. repository-name"
+            maxLength={100}
           />
           <FormControl.Caption>
             This is a private mirror of{' '}

--- a/src/server/repos/schema.ts
+++ b/src/server/repos/schema.ts
@@ -5,7 +5,7 @@ export const CreateMirrorSchema = z.object({
   forkRepoOwner: z.string(),
   forkRepoName: z.string(),
   forkId: z.string(),
-  newRepoName: z.string(),
+  newRepoName: z.string().max(100),
   newBranchName: z.string(),
 })
 
@@ -17,7 +17,7 @@ export const ListMirrorsSchema = z.object({
 export const EditMirrorSchema = z.object({
   orgId: z.string(),
   mirrorName: z.string(),
-  newMirrorName: z.string(),
+  newMirrorName: z.string().max(100),
 })
 
 export const DeleteMirrorSchema = z.object({

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -277,20 +277,8 @@ describe('Repos router', () => {
         newRepoName: 'a'.repeat(101),
       })
       .catch((error) => {
-        expect(error.message).toEqual(
-          '[\n\
-  {\n\
-    "code": "too_big",\n\
-    "maximum": 100,\n\
-    "type": "string",\n\
-    "inclusive": true,\n\
-    "exact": false,\n\
-    "message": "String must contain at most 100 character(s)",\n\
-    "path": [\n\
-      "newRepoName"\n\
-    ]\n\
-  }\n\
-]',
+        expect(error.message).toMatch(
+          /String must contain at most 100 character\(s\)/,
         )
       })
   })

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -263,4 +263,35 @@ describe('Repos router', () => {
     })
     expect(stubbedGit.clone).toHaveBeenCalledTimes(1)
   })
+
+  it('reject repository names over the character limit', async () => {
+    const caller = reposRouter.createCaller(createTestContext())
+
+    await caller
+      .createMirror({
+        forkId: 'test',
+        orgId: 'test',
+        forkRepoName: 'fork-test',
+        forkRepoOwner: 'github',
+        newBranchName: 'test',
+        newRepoName: 'a'.repeat(101),
+      })
+      .catch((error) => {
+        expect(error.message).toEqual(
+          '[\n\
+  {\n\
+    "code": "too_big",\n\
+    "maximum": 100,\n\
+    "type": "string",\n\
+    "inclusive": true,\n\
+    "exact": false,\n\
+    "message": "String must contain at most 100 character(s)",\n\
+    "path": [\n\
+      "newRepoName"\n\
+    ]\n\
+  }\n\
+]',
+        )
+      })
+  })
 })


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
fixes #135

This pull request limits the length of repository names in the application. The changes ensure that both the creation and editing of mirrors enforce a maximum length of 100 characters for the repository name. This is achieved through changes in the frontend and backend validation schemas.

## For Reviewers
- I want to add tests but wasn't able to find where we are already testing the mirror creation process. Is there a good spot to add a test for this? Maybe `test/app.test.ts`?
- Did I miss any spots that also need the limit enforced?

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
