### PR TITLE
fix: edit mirror dialog to display current mirror name

### DIFF
--- a/src/app/components/dialog/EditMirrorDialog.tsx
+++ b/src/app/components/dialog/EditMirrorDialog.tsx
@@ -74,7 +74,7 @@ export const EditMirrorDialog = ({
           <TextInput
             onChange={(e) => setNewMirrorName(e.target.value)}
             block
-            placeholder={newMirrorName}
+            placeholder={mirrorName}
             maxLength={100}
           />
           <FormControl.Caption>

--- a/src/app/components/dialog/EditMirrorDialog.tsx
+++ b/src/app/components/dialog/EditMirrorDialog.tsx
@@ -2,7 +2,7 @@ import { Box, FormControl, Label, Link, Text, TextInput } from '@primer/react'
 import { Stack } from '@primer/react/lib-esm/Stack'
 import { Dialog } from '@primer/react/lib-esm/drafts'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface EditMirrorDialogProps {
   orgLogin: string
@@ -31,6 +31,10 @@ export const EditMirrorDialog = ({
 }: EditMirrorDialogProps) => {
   // set to the current mirror name for display purposes
   const [newMirrorName, setNewMirrorName] = useState(mirrorName)
+
+  useEffect(() => {
+    setNewMirrorName(mirrorName)
+  }, [mirrorName, setNewMirrorName])
 
   if (!isOpen) {
     return null

--- a/src/app/components/dialog/EditMirrorDialog.tsx
+++ b/src/app/components/dialog/EditMirrorDialog.tsx
@@ -29,8 +29,8 @@ export const EditMirrorDialog = ({
   closeDialog,
   editMirror,
 }: EditMirrorDialogProps) => {
-  // set to default value of 'repository-name' for display purposes
-  const [newMirrorName, setNewMirrorName] = useState('repository-name')
+  // set to the current mirror name for display purposes
+  const [newMirrorName, setNewMirrorName] = useState(mirrorName)
 
   if (!isOpen) {
     return null
@@ -45,7 +45,7 @@ export const EditMirrorDialog = ({
           content: 'Cancel',
           onClick: () => {
             closeDialog()
-            setNewMirrorName('repository-name')
+            setNewMirrorName(mirrorName)
           },
         },
         {
@@ -57,14 +57,14 @@ export const EditMirrorDialog = ({
               mirrorName,
               newMirrorName,
             })
-            setNewMirrorName('repository-name')
+            setNewMirrorName(mirrorName)
           },
-          disabled: newMirrorName === 'repository-name' || newMirrorName === '',
+          disabled: newMirrorName === mirrorName || newMirrorName === '',
         },
       ]}
       onClose={() => {
         closeDialog()
-        setNewMirrorName('repository-name')
+        setNewMirrorName(mirrorName)
       }}
       width="large"
     >
@@ -74,7 +74,7 @@ export const EditMirrorDialog = ({
           <TextInput
             onChange={(e) => setNewMirrorName(e.target.value)}
             block
-            placeholder="e.g. repository-name"
+            placeholder={newMirrorName}
             maxLength={100}
           />
           <FormControl.Caption>


### PR DESCRIPTION
# Pull Request

fixes #136 

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
Updates the 'Edit mirror' dialog to display the current mirror name instead of the placeholder text 'repository-name'.
- Changes the initial state of `newMirrorName` to use the `mirrorName` prop, ensuring the current mirror name is displayed when the dialog opens.
- Updates the placeholder in the `TextInput` component to display the current mirror name, enhancing user experience by showing relevant information.
- Adjusts the logic for resetting `newMirrorName` upon dialog actions (cancel, confirm, close) to revert to the current mirror name instead of the placeholder, maintaining consistency with the initial state change.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `npm run lint` and fix any linting issues that have been introduced
- [x] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
