### PR TITLE
fix: replace deprecated createCaller

### DIFF
--- a/test/server/auth.test.ts
+++ b/test/server/auth.test.ts
@@ -1,6 +1,7 @@
 import { healthCheckerRouter } from '../../src/app/api/trpc/trpc-router'
 import { Octomock } from '../octomock'
 import { createTestContext } from '../utils/auth'
+import { t } from '../../src/utils/trpc-server'
 const om = new Octomock()
 
 jest.mock('../../src/bot/octokit', () => ({
@@ -14,7 +15,8 @@ describe('Git router', () => {
   })
 
   it('should allow users that are authenticated', async () => {
-    const caller = healthCheckerRouter.createCaller(createTestContext())
+    const caller =
+      t.createCallerFactory(healthCheckerRouter)(createTestContext())
 
     om.mockFunctions.rest.users.getAuthenticated.mockResolvedValue({
       status: 200,
@@ -33,7 +35,7 @@ describe('Git router', () => {
   })
 
   it('should throw on invalid sessions', async () => {
-    const caller = healthCheckerRouter.createCaller(
+    const caller = t.createCallerFactory(healthCheckerRouter)(
       createTestContext({
         user: {
           name: 'fake-username',

--- a/test/server/repos.test.ts
+++ b/test/server/repos.test.ts
@@ -18,6 +18,7 @@ import * as auth from '../../src/utils/auth'
 import reposRouter from '../../src/server/repos/router'
 import { Octomock } from '../octomock'
 import { createTestContext } from '../utils/auth'
+import { t } from '../../src/utils/trpc-server'
 const om = new Octomock()
 
 jest.mock('../../src/bot/config')
@@ -106,7 +107,7 @@ describe('Repos router', () => {
   })
 
   it('should create a mirror when repo does not exist exist', async () => {
-    const caller = reposRouter.createCaller(createTestContext())
+    const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = jest.spyOn(config, 'getConfig').mockResolvedValue({
       publicOrg: 'github',
@@ -151,7 +152,7 @@ describe('Repos router', () => {
   })
 
   it('should throw an error when repo already exists', async () => {
-    const caller = reposRouter.createCaller(createTestContext())
+    const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = jest.spyOn(config, 'getConfig').mockResolvedValue({
       publicOrg: 'github',
@@ -185,7 +186,7 @@ describe('Repos router', () => {
   })
 
   it('should cleanup repos when there is an error', async () => {
-    const caller = reposRouter.createCaller(createTestContext())
+    const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = jest.spyOn(config, 'getConfig').mockResolvedValue({
       publicOrg: 'github',
@@ -225,7 +226,7 @@ describe('Repos router', () => {
   })
 
   it('dual-org: should cleanup repos when there is an error', async () => {
-    const caller = reposRouter.createCaller(createTestContext())
+    const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     const configSpy = jest.spyOn(config, 'getConfig').mockResolvedValue({
       publicOrg: 'github',
@@ -265,7 +266,7 @@ describe('Repos router', () => {
   })
 
   it('reject repository names over the character limit', async () => {
-    const caller = reposRouter.createCaller(createTestContext())
+    const caller = t.createCallerFactory(reposRouter)(createTestContext())
 
     await caller
       .createMirror({


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

- Closes #174 
  - Replaces deprecated `createCaller` with `t.createCallerFactory`

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [X] run `npm run lint` and fix any linting issues that have been introduced
- [X] run `npm run test` and run tests
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [X] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
